### PR TITLE
Add support for custom section selectors

### DIFF
--- a/examples/selectors.js
+++ b/examples/selectors.js
@@ -6,7 +6,7 @@ const Section = require('../src/Section').default;
 const Intent = require('../src/Intent').default;
 const Transformer = require('../src/Transformer').default;
 
-class SelectorStore extends Store {
+class ImmutableStore extends Store {
     constructor(...args) {
         super(...args);
     }

--- a/examples/selectors.js
+++ b/examples/selectors.js
@@ -54,7 +54,7 @@ const setAddressField = Intent(SET_ADDRESS_FIELD, (order, {field, value}) => ord
 const ADD_ITEM_TO_ORDER = 'intent/ADD_ITEM_TO_ORDER';
 const addItemToOrder = Intent(ADD_ITEM_TO_ORDER, (order, item) => order.update('items', (items) => items.push(Immutable.fromJS(item))));
 
-const store = new SelectorStore();
+const store = new ImmutableStore();
 store.addSection('order', Section(initialOrderState, setName, setAddressField, addItemToOrder));
 
 const nameTransformer = Transformer(['order.name'], ([name]) => name);

--- a/examples/selectors.js
+++ b/examples/selectors.js
@@ -1,0 +1,80 @@
+require("babel-register");
+
+const Immutable = require('immutable');
+const Store = require('../src/Store').default;
+const Section = require('../src/Section').default;
+const Intent = require('../src/Intent').default;
+const Transformer = require('../src/Transformer').default;
+
+class SelectorStore extends Store {
+    constructor(...args) {
+        super(...args);
+    }
+
+    mapSelectorToSectionName(sectionSelector) {
+        return sectionSelector.split('.')[0];
+    }
+
+    getValuesForSelectors(sectionSelectors) {
+        return sectionSelectors.map(sectionSelector => {
+            const valueSelectors = sectionSelector.split('.');
+            const [sectionName, ...selectors] = valueSelectors;
+            const section = this.sections[sectionName];
+
+            if (section == null) return null;
+
+            const sectionValue = section.value;
+            if (selectors.length === 0) {
+                return sectionValue;
+            } else {
+                return sectionValue.getIn(selectors);
+            }
+        });
+    }
+}
+
+const initialOrderState = Immutable.fromJS({
+    name: 'asdf',
+    address: {
+        line1: '',
+        line2: '',
+        city: '',
+        state: '',
+        zip: ''
+    },
+    items: []
+});
+
+const SET_NAME = 'intent/SET_NAME';
+const setName = Intent(SET_NAME, (order, name) => order.set('name', name));
+
+const SET_ADDRESS_FIELD = 'intent/SET_ADDRESS_FIELD';
+const setAddressField = Intent(SET_ADDRESS_FIELD, (order, {field, value}) => order.setIn(['address', field], value));
+
+const ADD_ITEM_TO_ORDER = 'intent/ADD_ITEM_TO_ORDER';
+const addItemToOrder = Intent(ADD_ITEM_TO_ORDER, (order, item) => order.update('items', (items) => items.push(Immutable.fromJS(item))));
+
+const store = new SelectorStore();
+store.addSection('order', Section(initialOrderState, setName, setAddressField, addItemToOrder));
+
+const nameTransformer = Transformer(['order.name'], ([name]) => name);
+store.subscribeTransformer(nameTransformer, name => console.log('name changed to', name));
+
+const addressTransformer = Transformer(['order.address'], ([address]) => address);
+store.subscribeTransformer(addressTransformer, address => console.log('address changed to', address.toJS()));
+
+const itemsTransformer = Transformer(['order.items'], ([address]) => address);
+store.subscribeTransformer(itemsTransformer, items => console.log('items changed to', items.toJS()));
+
+// enough setup, now GO
+
+store.dispatch(SET_NAME, 'Chandler');
+
+store.dispatch(SET_ADDRESS_FIELD, {field: 'line1', value: '123 Main St.'});
+store.dispatch(SET_ADDRESS_FIELD, {field: 'city', value: 'Denver'});
+store.dispatch(SET_ADDRESS_FIELD, {field: 'state', value: 'Colorado'});
+store.dispatch(SET_ADDRESS_FIELD, {field: 'zip', value: '80202'});
+
+store.dispatch(ADD_ITEM_TO_ORDER, {name: 'Cookies', quantity: 2, price: '4.98'});
+store.dispatch(ADD_ITEM_TO_ORDER, {name: 'Milk', quantity: 1, price: '1.99'});
+store.dispatch(ADD_ITEM_TO_ORDER, {name: 'Santa Trap', quantity: 1, price: '999.99'});

--- a/examples/selectors.js
+++ b/examples/selectors.js
@@ -34,7 +34,7 @@ class ImmutableStore extends Store {
 }
 
 const initialOrderState = Immutable.fromJS({
-    name: 'asdf',
+    name: '',
     address: {
         line1: '',
         line2: '',

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "babel": "^6.5.2",
     "babel-plugin-transform-object-rest-spread": "^6.16.0",
     "babel-preset-es2015": "^6.16.0",
-    "babel-register": "^6.16.3"
+    "babel-register": "^6.16.3",
+    "immutable": "^3.8.1"
   },
   "ava": {
     "timeout": "5s",


### PR DESCRIPTION
Modified Store to support section selectors. Tests are passing.

Added [`selectors` example](https://github.com/chandlerprall/capacitor/blob/feature/selectors/examples/selectors.js). This demonstrates how transformers can subscribe to children of a section. In this case, we extend the `Store` class to understand dot-separated selectors (e.g. `one.two.three`) and subscribe to those parts of the data.

This does nothing to try and optimize not calling transformers, but it does help limit a transformer's scope. It would be simple to add support to verify that transformer input has changed and only execute the transform if its input has changed, but this should be delayed until selector support lands.

The example's output is:

```
name changed to Chandler
address changed to { line1: '123 Main St.',
  line2: '',
  city: 'Denver',
  state: 'Colorado',
  zip: '80202' }
items changed to [ { name: 'Cookies', quantity: 2, price: '4.98' },
  { name: 'Milk', quantity: 1, price: '1.99' },
  { name: 'Santa Trap', quantity: 1, price: '999.99' } ]
```
