### PR TITLE
sort subscribers by their dependency depth before calling

### DIFF
--- a/packages/insula/src/Store.js
+++ b/packages/insula/src/Store.js
@@ -282,6 +282,5 @@ Store.prototype.findComputedStateDependencyDepth = function findComputedStateDep
             dependencyDepths.push(this.computedStateDepths[selectors[i][1]]);
         }
     }
-    var computedStateDependencyDepth = Math.max.apply(null, dependencyDepths);
-    return computedStateDependencyDepth;
+    return Math.max.apply(null, dependencyDepths);
 };

--- a/packages/insula/src/Store.js
+++ b/packages/insula/src/Store.js
@@ -237,10 +237,10 @@ function subscriberSorter(a, b) {
 }
 Store.prototype.callSubscribers = function callSubscribers() {
     this.nextSubscriberCalls.sort(subscriberSorter);
-    for (var i = 0; i < this.nextSubscriberCalls.length; i++) {
-        this.nextSubscriberCalls[i]();
+    while (this.nextSubscriberCalls.length > 0) {
+        var subscriber = this.nextSubscriberCalls.shift(1); // pull the next subscriber from front of the array
+        subscriber.call(this);
     }
-    this.nextSubscriberCalls.length = 0;
 };
 
 Store.prototype.addComputed = function addComputed(computedLabel, selectors, computator) {

--- a/packages/insula/src/Store.js
+++ b/packages/insula/src/Store.js
@@ -31,6 +31,7 @@ export default function Store(initialState, middleware) {
     this.nextSubscriberCalls = [];
 
     this.computedState = {};
+    this.computedStateDepths = {};
     this.setState(initialState !== undefined ? initialState : {});
     
     // call any middleware constructors
@@ -192,6 +193,9 @@ Store.prototype.subscribeToState = function subscribeToState(selectors, listener
         // call listener with all the state values
         processedListener(stateValues);
     };
+
+    // find the computed dependency depth for these selectors and attach it to the subscription function
+    stateChangeListener.dependencyDepth = this.findComputedStateDependencyDepth(selectors);
     
     for (i = 0; i < processedSelectors.length; i++) {
         this.subscriptions.subscribeSelector(processedSelectors[i], stateChangeListener);
@@ -222,7 +226,17 @@ Store.prototype.callSubscribersUnderSelector = function callSubscribersUnderSele
     }
 };
 
+function subscriberSorter(a, b) {
+    if (a.dependencyDepth < b.dependencyDepth) {
+        return -1;
+    } else if (a.dependencyDepth === b.dependencyDepth) {
+        return 0;
+    } else {
+        return 1;
+    }
+}
 Store.prototype.callSubscribers = function callSubscribers() {
+    this.nextSubscriberCalls.sort(subscriberSorter);
     for (var i = 0; i < this.nextSubscriberCalls.length; i++) {
         this.nextSubscriberCalls[i]();
     }
@@ -239,6 +253,10 @@ Store.prototype.addComputed = function addComputed(computedLabel, selectors, com
         stateValues.push(this.getPartialState(selectors[i]));
     }
 
+    // find this computed state's dependency depth on other computed states, and set it +1 for itself being computed
+    var dependencyDepth = this.findComputedStateDependencyDepth(selectors);
+    this.computedStateDepths[computedLabel] = dependencyDepth + 1; // set this computed state's dependency depth to the max found + 1
+
     var computedStateSelector = [COMPUTED_FLAG, computedLabel];
 
     var computedValue = computator(stateValues);
@@ -254,4 +272,16 @@ Store.prototype.addComputed = function addComputed(computedLabel, selectors, com
     );
 
     return computedStateSelector;
+};
+
+// findComputedStateDependencyDepth determines maximum nested depth of computed state dependencies exist in an array of selectors
+Store.prototype.findComputedStateDependencyDepth = function findComputedStateDependencyDepth(selectors) {
+    var dependencyDepths = [0]; // represent any non-computed states selected
+    for (var i = 0; i < selectors.length; i++) {
+        if (selectors[i][0] === COMPUTED_FLAG) {
+            dependencyDepths.push(this.computedStateDepths[selectors[i][1]]);
+        }
+    }
+    var computedStateDependencyDepth = Math.max.apply(null, dependencyDepths);
+    return computedStateDependencyDepth;
 };

--- a/packages/insula/src/Store.js
+++ b/packages/insula/src/Store.js
@@ -239,7 +239,7 @@ Store.prototype.callSubscribers = function callSubscribers() {
     this.nextSubscriberCalls.sort(subscriberSorter);
     while (this.nextSubscriberCalls.length > 0) {
         var subscriber = this.nextSubscriberCalls.shift(1); // pull the next subscriber from front of the array
-        subscriber.call(this);
+        subscriber();
     }
 };
 


### PR DESCRIPTION
Found my edge case.

* Store has A and B. There's a computed C which is derived solely from B.
* Add subscription for [A, C]
* Set A, callback queue adds Subscription and C
* Set B, callback queue attempts to add C but it's already queued, does nothing
* Subscription callback fires and gets values for A, C (C is out of date)
* C callback fired, updating computed state C derived from B (C is now back up-to-date)

This PR contains two fixes:
1. `Store.prototype.callSubscribers` now removes subscribers from the queue as soon as they have been processed. The above steps should have included _Subscriber re-queued because C changed, called with A, C_ but the subscription function was still in the queue array. This was the bugbugbug where the subscriber was not ever told about a relevant value change
2. Dependency tree depth is now tracked and used to sort the subscription queue before iterating over it. This sorting optimizes the call order so that in the above situation C is called first, updating the computed value before Subscription is called.

There's still a possibility that multiple state/computed state interactions occur and the single queue sort is not enough to correctly optimize the call order. Because computed states cannot be circular, it _is_ possible to determine the correct call order but you have to re-sort the queue after every subscription call in case other subscriptions have been added to the queue. This is really inefficient and bugfix 1 above guarantees that even if some subscriptions are called out of turn they will, soon after, be called with the correct information. This inefficiency can be avoided by implementing the queue as a [minheap](https://en.wikipedia.org/wiki/Binary_heap) which means sorting only happens on item insertion. This PR will get things most of the way and then I'll follow up with the minheap.